### PR TITLE
Open authorization URL in a new window

### DIFF
--- a/scripts/Authorize.html
+++ b/scripts/Authorize.html
@@ -20,14 +20,14 @@
   <tr>
     <td width='50%'>
       <div style='padding-left:40%'>
-        <a href='<?!=authorizationUrl?>'>
+        <a target="_blank" href='<?!=authorizationUrl?>'>
           <img src='https://lh3.googleusercontent.com/yesd0T2xGihM082cMaozc22cRdBl6OyqzxPKwMGE6W0=w764-h318-no' width='60%'/>
         </a>
       </div>
     </td>
     <td width='50%'>
       <div style='padding-left:20%'>
-        <a href='<?!=authorizationUrl?>'>
+        <a target="_blank" href='<?!=authorizationUrl?>'>
           <img src='https://lh3.googleusercontent.com/xE3e0LFvoUctJ9rzTjvo0Z1Fo_Xqx78FSXP-zbRGt1k=w596-h632-no' width='70%' />
         </a>
       </div>
@@ -35,7 +35,7 @@
   </tr>
   <tr>
     <td colspan='2' align='center'>
-      <a href='<?!=authorizationUrl?>'>Click to authorize Google Apps integration </a>
+      <a target="blank_" href='<?!=authorizationUrl?>'>Click to authorize Google Apps integration </a>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
This change prevents HTMLService from
opening the URL in an iframe, which sometimes causes the
authorization page to not load.

Addresses #4 
